### PR TITLE
cmake build functional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ cmake_minimum_required(VERSION 2.8)
 set (VERSION 1.6.9)
 
 add_definitions (-DCMAKE -DVERSION=\"${VERSION}\")
+add_definitions (-DWITH_EPOLL)
 
 if (WIN32)
 	add_definitions("-D_CRT_SECURE_NO_WARNINGS")
@@ -28,6 +29,13 @@ option(WITH_TLS_PSK
 	"Include TLS-PSK support (requires WITH_TLS)?" ON)
 option(WITH_EC
 	"Include Elliptic Curve support (requires WITH_TLS)?" ON)
+
+option(WITH_CJSON 
+	"Build bridge with json support" ON)
+if (WITH_CJSON)
+	add_definitions("-DWITH_CJSON")
+endif (WITH_CJSON)
+
 if (WITH_TLS)
 	find_package(OpenSSL REQUIRED)
 	add_definitions("-DWITH_TLS")

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,18 +1,23 @@
-include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/lib
+
+include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/src ${mosquitto_SOURCE_DIR}/lib
 			${STDBOOL_H_PATH} ${STDINT_H_PATH} ${PTHREAD_INCLUDE_DIR}
 			${OPENSSL_INCLUDE_DIR})
 link_directories(${mosquitto_BINARY_DIR}/lib)
 
 set(shared_src client_shared.c client_shared.h client_props.c)
 
+add_executable(mosquitto_pub pub_client.c pub_shared.c ${shared_src})
+add_executable(mosquitto_sub sub_client.c sub_client_output.c ${shared_src})
+add_executable(mosquitto_rr rr_client.c pub_shared.c sub_client_output.c ${shared_src})
+add_executable(mosquitto_bridge bridge_client.c ${shared_src} pub_shared.c)
+
 if (WITH_SRV)
 	add_definitions("-DWITH_SRV")
 endif (WITH_SRV)
 
-add_executable(mosquitto_pub pub_client.c pub_shared.c ${shared_src})
-add_executable(mosquitto_sub sub_client.c sub_client_output.c ${shared_src})
-add_executable(mosquitto_rr rr_client.c pub_shared.c sub_client_output.c ${shared_src})
-add_executable(mosquitto_bridge bridge_client.c ${shared_src})
+if (WITH_CJSON)
+	target_link_libraries(mosquitto_bridge cjson)
+endif (WITH_CJSON)
 
 if (WITH_STATIC_LIBRARIES)
 	target_link_libraries(mosquitto_pub libmosquitto_static)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,7 @@ endif (WITH_BUNDLED_DEPS)
 option(INC_BRIDGE_SUPPORT
 	"Include bridge support for connecting to other brokers?" ON)
 if (INC_BRIDGE_SUPPORT)
-	set (MOSQ_SRCS ${MOSQ_SRCS} bridge.c)
+	set (MOSQ_SRCS ${MOSQ_SRCS} bridge.c bridge_dynamic.c)
 	add_definitions("-DWITH_BRIDGE")
 endif (INC_BRIDGE_SUPPORT)
 
@@ -177,6 +177,10 @@ if (WITH_WEBSOCKETS)
 		set (MOSQ_LIBS ${MOSQ_LIBS} websockets)
 	endif (STATIC_WEBSOCKETS)
 endif (WITH_WEBSOCKETS)
+
+if (WITH_CJSON)
+        set (MOSQ_LIBS ${MOSQ_LIBS} cjson)
+endif (WITH_CJSON)
 
 add_executable(mosquitto ${MOSQ_SRCS})
 target_link_libraries(mosquitto ${MOSQ_LIBS})


### PR DESCRIPTION
- turn on EPOLL by default because it is used in moquitto_bridge
- link CJSON when WITH_CJSON is turned on (default)
- add bridge_dynamic.c to mosquitto build src
- add src includes to client builds